### PR TITLE
Add a raw json field for legislation

### DIFF
--- a/config/default/core.entity_form_display.node.legislation.default.yml
+++ b/config/default/core.entity_form_display.node.legislation.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_date
     - field.field.node.legislation.field_publication_name
+    - field.field.node.legislation.field_raw_json
     - field.field.node.legislation.field_repeal
     - field.field.node.legislation.field_stub
     - field.field.node.legislation.field_tags
@@ -113,6 +114,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_raw_json:
+    weight: 28
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
     region: content
   field_repeal:
     type: entity_reference_paragraphs

--- a/config/default/core.entity_view_display.node.legislation.default.yml
+++ b/config/default/core.entity_view_display.node.legislation.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_date
     - field.field.node.legislation.field_publication_name
+    - field.field.node.legislation.field_raw_json
     - field.field.node.legislation.field_repeal
     - field.field.node.legislation.field_stub
     - field.field.node.legislation.field_tags
@@ -128,6 +129,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_raw_json:
+    weight: 17
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   field_repeal:
     type: entity_reference_revisions_entity_view

--- a/config/default/field.field.node.legislation.field_raw_json.yml
+++ b/config/default/field.field.node.legislation.field_raw_json.yml
@@ -1,0 +1,19 @@
+uuid: ebed0716-c102-4a6c-bc8b-9f9577bf82a0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_raw_json
+    - node.type.legislation
+id: node.legislation.field_raw_json
+field_name: field_raw_json
+entity_type: node
+bundle: legislation
+label: 'Raw JSON'
+description: 'Raw Indigo JSON'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.storage.node.field_raw_json.yml
+++ b/config/default/field.storage.node.field_raw_json.yml
@@ -1,0 +1,19 @@
+uuid: 6a1ebdd8-6381-4ef2-92eb-010ea0519352
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_raw_json
+field_name: field_raw_json
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
This allows us to stash the entire json description of the work expression, for cases where we want to pull a field from the json but don't want to have to model it as a field in drupal.

@cristiroma @roger-cts my first attempt at creating a new field -- pls let me know if it's incorrect.