### PR TITLE
Max PDF file size is 20MB

### DIFF
--- a/config/default/field.field.node.legislation.field_files.yml
+++ b/config/default/field.field.node.legislation.field_files.yml
@@ -20,7 +20,7 @@ default_value_callback: ''
 settings:
   file_directory: legislation/files
   file_extensions: 'txt doc docx pdf epub'
-  max_filesize: ''
+  max_filesize: 20MB
   description_field: true
   handler: 'default:file'
   handler_settings: {  }

--- a/web/.user.ini
+++ b/web/.user.ini
@@ -1,0 +1,2 @@
+post_max_size = 30M
+upload_max_filesize = 20M


### PR DESCRIPTION
Our PDFs are bigger than the default of 2MB
