### PR TITLE
Migrations

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "scripts": {
     "dokku": {
       "predeploy": "mkdir -p web/sites/default/files/translations/",
-      "postdeploy": "bin/post-deploy.sh"
+      "postdeploy": "scripts/post-deploy.sh"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "dokku": {
-      "postdeploy": "vendor/drush/drush/drush updatedb -y && vendor/drush/drush/drush cim sync -y && vendor/drush/drush/drush updatedb -y && vendor/drush/drush/drush cr"
+      "predeploy": "mkdir -p web/sites/default/files/translations/",
+      "postdeploy": "bin/post-deploy.sh"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "dokku": {
+      "postdeploy": "vendor/drush/drush/drush updatedb -y && vendor/drush/drush/drush cim sync -y && vendor/drush/drush/drush updatedb -y && vendor/drush/drush/drush cr"
+    }
+  }
+}

--- a/docs/production.md
+++ b/docs/production.md
@@ -108,3 +108,5 @@ To deploy, simply push to the dokku remote: `git push dokku`
 This will push your changes to the server, Dokku will build a new Docker container with Drupal and all necessary dependencies.
 Dokku will only swap the new container in place if the deployment succeeds, otherwise the old container is left running
 and nothing changes.
+
+Dokku will automatically run database updates and migrations after each deployment.

--- a/scripts/post-deploy.sh
+++ b/scripts/post-deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+drush=vendor/drush/drush/drush
+
+# this is run by dokku once the deployment is complete
+# changes made to the file system are NOT persisted
+#
+# ref: http://dokku.viewdocs.io/dokku/advanced-usage/deployment-tasks/#appjson-deployment-tasks
+
+$drush state-set system.maintenance_mode TRUE && \
+$drush updatedb -y && \
+$drush cr && \
+$drush cim sync -y && \
+$drush updatedb -y && \
+$drush locale:check && \
+$drush locale:update && \
+$drush cr && \
+$drush state-set system.maintenance_mode FALSE

--- a/scripts/post-deploy.sh
+++ b/scripts/post-deploy.sh
@@ -8,12 +8,20 @@ drush=vendor/drush/drush/drush
 #
 # ref: http://dokku.viewdocs.io/dokku/advanced-usage/deployment-tasks/#appjson-deployment-tasks
 
+# 1. Set the site into maintenance mode, this lowers the chances of DB transaction deadlocks
 $drush state-set system.maintenance_mode TRUE && \
+# 2. Run updatedb #1 (some modules update before the config import)
 $drush updatedb -y && \
+# 3. Clear caches
 $drush cr && \
+# 4. Run config import
 $drush cim sync -y && \
+# 5. Run updatedb #2 (some modules update AFTER the config import)
 $drush updatedb -y && \
+# 6. Update module string translations
 $drush locale:check && \
 $drush locale:update && \
+# 7. Clear caches one more time
 $drush cr && \
+# 8. Remove maintenance mode
 $drush state-set system.maintenance_mode FALSE

--- a/scripts/post-deploy.sh
+++ b/scripts/post-deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -xeo pipefail
 
 drush=vendor/drush/drush/drush
 


### PR DESCRIPTION
This causes dokku to run database migrations (`drush updatedb -y` etc.) and updates the cache (`drush cr`) after each deployment.