### PR TITLE
Disabling file field paths for Judgment and Gazette download fields.

### DIFF
--- a/config/default/field.field.node.government_gazette.field_file.yml
+++ b/config/default/field.field.node.government_gazette.field_file.yml
@@ -10,7 +10,7 @@ dependencies:
     - filefield_paths
 third_party_settings:
   filefield_paths:
-    enabled: true
+    enabled: false
     file_path:
       value: ''
       options:
@@ -37,8 +37,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: txt
+  file_directory: government_gazette/files
+  file_extensions: pdf
   max_filesize: '50 MB'
   description_field: false
   handler: 'default:file'

--- a/config/default/field.field.node.judgment.field_files.yml
+++ b/config/default/field.field.node.judgment.field_files.yml
@@ -10,7 +10,7 @@ dependencies:
     - filefield_paths
 third_party_settings:
   filefield_paths:
-    enabled: true
+    enabled: false
     file_path:
       value: ''
       options:
@@ -37,7 +37,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_directory: judgment/files
   file_extensions: 'txt doc docx xls pdf ppt pps odt ods odp rtf'
   max_filesize: '50 MB'
   description_field: false


### PR DESCRIPTION
Disabled file field paths for the gazette and judgement download field in order to allow json api to function correctly. Also specified new paths as 'content type'/file with respective content type names.