### PR TITLE
Legislation lifecycle as json field

### DIFF
--- a/config/default/core.entity_form_display.node.legislation.default.yml
+++ b/config/default/core.entity_form_display.node.legislation.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_date
     - field.field.node.legislation.field_publication_name
@@ -35,13 +36,13 @@ bundle: legislation
 mode: default
 content:
   field_commencement_date:
-    weight: 7
+    weight: 9
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_content:
-    weight: 14
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -49,19 +50,19 @@ content:
     type: text_textarea
     region: content
   field_created:
-    weight: 4
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_expression_date:
-    weight: 26
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_external_link:
-    weight: 27
+    weight: 16
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -69,14 +70,14 @@ content:
     type: link_default
     region: content
   field_files:
-    weight: 16
+    weight: 15
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
     type: file_generic
     region: content
   field_frbr_uri:
-    weight: 8
+    weight: 1
     settings:
       size: 60
       placeholder: ''
@@ -84,15 +85,23 @@ content:
     type: string_textfield
     region: content
   field_images:
-    weight: 15
+    weight: 14
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
     region: content
+  field_lifecycle_json:
+    weight: 19
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
   field_parent_work:
-    weight: 9
+    weight: 10
     settings:
       match_operator: CONTAINS
       size: 60
@@ -102,13 +111,13 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_publication_date:
-    weight: 5
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_publication_name:
-    weight: 6
+    weight: 8
     settings:
       size: 60
       placeholder: ''
@@ -116,7 +125,7 @@ content:
     type: string_textfield
     region: content
   field_raw_json:
-    weight: 28
+    weight: 20
     settings:
       rows: 5
       placeholder: ''
@@ -136,20 +145,20 @@ content:
     third_party_settings: {  }
     region: content
   field_stub:
-    weight: 3
+    weight: 5
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_tags:
-    weight: 10
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_toc:
-    weight: 13
+    weight: 18
     settings:
       rows: 5
       placeholder: ''
@@ -158,7 +167,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 1
+    weight: 2
     region: content
     settings:
       include_locked: true
@@ -167,12 +176,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 17
+    weight: 13
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 120

--- a/config/default/core.entity_view_display.node.legislation.default.yml
+++ b/config/default/core.entity_view_display.node.legislation.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_date
     - field.field.node.legislation.field_publication_name
@@ -65,6 +66,7 @@ hidden:
   field_external_link: true
   field_files: true
   field_images: true
+  field_lifecycle_json: true
   field_publication_date: true
   field_publication_name: true
   field_raw_json: true

--- a/config/default/core.entity_view_display.node.legislation.full.yml
+++ b/config/default/core.entity_view_display.node.legislation.full.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_date
     - field.field.node.legislation.field_publication_name
@@ -45,6 +46,13 @@ content:
     label: hidden
     settings:
       use_description_as_link_text: true
+    third_party_settings: {  }
+  field_lifecycle_json:
+    type: basic_string
+    weight: 6
+    region: content
+    label: hidden
+    settings: {  }
     third_party_settings: {  }
   field_parent_work:
     weight: 3

--- a/config/default/core.entity_view_display.node.legislation.teaser.yml
+++ b/config/default/core.entity_view_display.node.legislation.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_date
     - field.field.node.legislation.field_publication_name
@@ -44,6 +45,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_lifecycle_json: true
   field_parent_work: true
   field_publication_date: true
   field_publication_name: true

--- a/config/default/field.field.node.legislation.field_lifecycle_json.yml
+++ b/config/default/field.field.node.legislation.field_lifecycle_json.yml
@@ -1,0 +1,19 @@
+uuid: 0c1cd859-ccae-45b3-b563-a4c3f7099552
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_lifecycle_json
+    - node.type.legislation
+id: node.legislation.field_lifecycle_json
+field_name: field_lifecycle_json
+entity_type: node
+bundle: legislation
+label: Lifecycle
+description: 'Lifecycle of this work, in JSON format.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/field.storage.node.field_lifecycle_json.yml
+++ b/config/default/field.storage.node.field_lifecycle_json.yml
@@ -1,0 +1,19 @@
+uuid: f7c2b065-7737-4840-b57a-2a0d916186a1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_lifecycle_json
+field_name: field_lifecycle_json
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/themes/custom/liibarrio/liibarrio.theme
+++ b/web/themes/custom/liibarrio/liibarrio.theme
@@ -37,8 +37,13 @@ function liibarrio_preprocess_page(&$variables) {
 }
 
 function liibarrio_preprocess_field__node__field_toc__legislation(&$variables, $hook) { 
-  $toc_data = $variables['items']['0']['content']['#context']['value'];
-  $variables['toc'] = Json::decode($toc_data);
+  $data = $variables['items']['0']['content']['#context']['value'];
+  $variables['toc'] = Json::decode($data);
+}
+
+function liibarrio_preprocess_field__node__field_lifecycle_json__legislation(&$variables, $hook) { 
+  $data = $variables['items']['0']['content']['#context']['value'];
+  $variables['lifecycle'] = Json::decode($data);
 }
 
 function liibarrio_preprocess_node__legislation(&$variables, $hook) {

--- a/web/themes/custom/liibarrio/templates/field--node--field-lifecycle-json--legislation.html.twig
+++ b/web/themes/custom/liibarrio/templates/field--node--field-lifecycle-json--legislation.html.twig
@@ -1,0 +1,34 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+<ol class="toc-list">
+  {% for entry in lifecycle %}
+    <li>{{ entry.date}}
+      <ul>
+        {% for event in entry.events %}
+          <li>{{ event.event }}</li>
+        {% endfor %}
+      </ul>
+  {% endfor %}
+</ol>

--- a/web/themes/custom/liibarrio/templates/node--legislation--full.html.twig
+++ b/web/themes/custom/liibarrio/templates/node--legislation--full.html.twig
@@ -131,7 +131,9 @@
     </div>
 
     {# History tab #}
-    <div class="tab-pane fade" id="history" role="tabpanel" aria-labelledby="history-tab">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Ipsa autem quos dolorem hic ullam atque, cupiditate praesentium, labore dolorum harum nisi numquam ab distinctio. Aliquam minima necessitatibus error non totam mollitia. Facilis voluptatum, inventore maxime ab delectus doloribus cupiditate minus!</div>
+    <div class="tab-pane fade" id="history" role="tabpanel" aria-labelledby="history-tab">
+      {{ content.field_lifecycle_json }}
+    </div>
   </div> 
 
 


### PR DESCRIPTION
This allows us to inject the lifecycle (an event timeline) of a piece of legislation, to make it easy to render the history tab.

It also adjusts ordering of elements in the legislation form.