### PR TITLE
Adjusting Judgment Importer to ignore Court name

### DIFF
--- a/config/default/feeds.feed_type.judgment_importer.yml
+++ b/config/default/feeds.feed_type.judgment_importer.yml
@@ -7,12 +7,10 @@ dependencies:
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number_numeric
     - field.field.node.judgment.field_case_number_year
-    - field.field.node.judgment.field_court_name
     - field.field.node.judgment.field_files
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_headnote_and_holding
     - field.field.node.judgment.field_judgment_date
-    - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number_override
     - field.field.node.judgment.field_judgment_old_nid
     - field.field.node.judgment.field_law_report_citations
@@ -60,10 +58,12 @@ label: 'Judgment Importer'
 description: 'Import content types of Judgment via json'
 help: ''
 import_period: 3600
-fetcher: upload
+fetcher: http
 fetcher_configuration:
-  allowed_extensions: 'txt csv tsv xml opml json'
-  directory: 'public://feeds'
+  auto_detect_feeds: false
+  use_pubsubhubbub: false
+  fallback_hub: ''
+  request_timeout: 6000
 parser: jsonpath
 parser_configuration:
   context:
@@ -75,9 +75,6 @@ parser_configuration:
     body:
       label: Body
       value: Body
-    _court_name_:
-      label: '[''Court Name'']'
-      value: '[''Court Name'']'
     _flynote_tags_:
       label: '[''Flynote tags'']'
       value: '[''Flynote tags'']'
@@ -119,7 +116,7 @@ parser_configuration:
 processor: 'entity:node'
 processor_configuration:
   langcode: en
-  update_existing: 0
+  update_existing: 1
   update_non_existent: _keep
   expire: -1
   owner_feed_author: false
@@ -217,14 +214,6 @@ mappings:
     settings:
       language: ''
       format: full_html
-  -
-    target: field_court_name
-    map:
-      target_id: _court_name_
-    settings:
-      language: ''
-      reference_by: name
-      autocreate: '1'
   -
     target: field_flynote
     map:

--- a/config/default/field.field.node.judgment.field_files.yml
+++ b/config/default/field.field.node.judgment.field_files.yml
@@ -15,7 +15,7 @@ third_party_settings:
       value: 'judgments/files/[node:field_court_name:entity]/[node:field_judgment_date:date:custom:Y]/[node:field_judgment_number:value]'
       options:
         slashes: false
-        pathauto: false
+        pathauto: true
         transliterate: false
     redirect: false
     retroactive_update: false
@@ -24,7 +24,7 @@ third_party_settings:
       value: '[node:field_media_neutral_citation:value].[file:ffp-extension-original]'
       options:
         slashes: false
-        pathauto: false
+        pathauto: true
         transliterate: false
 id: node.judgment.field_files
 field_name: field_files
@@ -40,7 +40,7 @@ settings:
   file_directory: judgment/files
   file_extensions: 'txt doc docx xls pdf ppt pps odt ods odp rtf'
   max_filesize: '100 MB'
-  description_field: true
+  description_field: false
   handler: 'default:file'
   handler_settings: {  }
 field_type: file


### PR DESCRIPTION
Court name taxonomy is constantly being reset currently stopping imports. 
Also set file field paths to use path auto for cleaning names.