### PR TITLE
Change legislation link in timeline chart

### DIFF
--- a/web/modules/custom/liiweb_legislation/js/timeline-graph.js
+++ b/web/modules/custom/liiweb_legislation/js/timeline-graph.js
@@ -18,7 +18,7 @@
 
       // link to read this version
       if (entry.expression_frbr_uri && entry.date != expressionInfo.expression_date) {
-        link = '<br/><a style="text-decoration: underline; font-weight: bold" href="/legislation' +
+        link = '<br/><a style="text-decoration: underline; font-weight: bold" href="' +
                entry.expression_frbr_uri + '">Read version</a>';
       }
 


### PR DESCRIPTION
Removes `/legislation` from the legislation links in the timeline chart.