### PR TITLE
Remove court name from judgment Alphabetised listing

### DIFF
--- a/config/default/views.view.judgments_listing.yml
+++ b/config/default/views.view.judgments_listing.yml
@@ -507,7 +507,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''


### PR DESCRIPTION
@Hayk-web have reviewed and merged your request, working correctly. The court field was just showing on the alphabetized listing page so have hidden it.