### PR TITLE
Adjust Views conditional to use correct filter

### DIFF
--- a/config/default/views.view.download_conditional.yml
+++ b/config/default/views.view.download_conditional.yml
@@ -252,63 +252,6 @@ display:
           or: '{{ body }}'
           strip_tags: 0
           plugin_id: views_conditional_field
-        id:
-          id: id
-          table: file_usage
-          field: id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          set_precision: false
-          precision: 0
-          decimal: .
-          separator: ','
-          format_plural: false
-          format_plural_string: !!binary MQNAY291bnQ=
-          prefix: ''
-          suffix: ''
-          plugin_id: numeric
       filters:
         status:
           value: '1'
@@ -357,22 +300,23 @@ display:
       empty: {  }
       relationships: {  }
       arguments:
-        id:
-          id: id
-          table: file_usage
-          field: id
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
           relationship: none
           group_type: group
           admin_label: ''
-          default_action: default
+          default_action: ignore
           exception:
             value: all
             title_enable: false
             title: All
           title_enable: false
           title: ''
-          default_argument_type: node
-          default_argument_options: {  }
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
           default_argument_skip_url: false
           summary_options:
             base_path: ''
@@ -390,7 +334,9 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          plugin_id: numeric
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
       display_extenders: {  }
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
Adjusted the Contextual Filter which was incorrectly set to file ID instead of content ID, causing body to be missing if a file was not attached to the node.