### PR TITLE
Addition of ISO Country Code field to Judgments and Legislation

### DIFF
--- a/config/default/core.entity_form_display.node.judgment.default.yml
+++ b/config/default/core.entity_form_display.node.judgment.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -78,6 +79,7 @@ third_party_settings:
         - title
         - field_case_name
         - field_matter_type
+        - field_iso_country_code
         - field_case_number_numeric
         - field_case_number_year
         - field_judgment_number
@@ -185,7 +187,7 @@ content:
     type: string_textfield
     region: content
   field_case_number:
-    weight: 26
+    weight: 23
     settings:
       size: 60
       placeholder: ''
@@ -193,7 +195,7 @@ content:
     type: string_textfield
     region: content
   field_case_number_numeric:
-    weight: 14
+    weight: 15
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -208,7 +210,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_case_number_year:
-    weight: 15
+    weight: 16
     settings:
       placeholder: ''
     third_party_settings: {  }
@@ -264,6 +266,16 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_iso_country_code:
+    weight: 14
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_judge:
     weight: 21

--- a/config/default/core.entity_form_display.node.legislation.default.yml
+++ b/config/default/core.entity_form_display.node.legislation.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -35,7 +36,7 @@ bundle: legislation
 mode: default
 content:
   field_as_at:
-    weight: 19
+    weight: 20
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -55,13 +56,13 @@ content:
     type: text_textarea
     region: content
   field_created:
-    weight: 14
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_date:
-    weight: 18
+    weight: 19
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -73,7 +74,7 @@ content:
     type: datetime_default
     region: content
   field_external_link:
-    weight: 13
+    weight: 14
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -88,8 +89,18 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_iso_country_code:
+    weight: 11
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   field_lifecycle_json:
-    weight: 16
+    weight: 17
     settings:
       rows: 5
       placeholder: ''
@@ -115,7 +126,7 @@ content:
     type: string_textfield
     region: content
   field_raw_json:
-    weight: 17
+    weight: 18
     settings:
       rows: 5
       placeholder: ''
@@ -142,13 +153,13 @@ content:
     type: boolean_checkbox
     region: content
   field_tags:
-    weight: 11
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_toc:
-    weight: 15
+    weight: 16
     settings:
       rows: 5
       placeholder: ''
@@ -166,7 +177,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 12
+    weight: 13
     region: content
     third_party_settings: {  }
   title:

--- a/config/default/core.entity_view_display.node.judgment.card_secondary.yml
+++ b/config/default/core.entity_view_display.node.judgment.card_secondary.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -108,6 +109,7 @@ hidden:
   field_flynote: true
   field_flynote_local: true
   field_headnote_and_holding: true
+  field_iso_country_code: true
   field_judge: true
   field_judgment_mnc_old: true
   field_judgment_number: true

--- a/config/default/core.entity_view_display.node.judgment.default.yml
+++ b/config/default/core.entity_view_display.node.judgment.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -197,6 +198,7 @@ hidden:
   field_case_number_old: true
   field_case_number_year: true
   field_external_link: true
+  field_iso_country_code: true
   field_judgment_mnc_old: true
   field_judgment_number: true
   field_judgment_number_override: true

--- a/config/default/core.entity_view_display.node.judgment.full.yml
+++ b/config/default/core.entity_view_display.node.judgment.full.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -257,6 +258,7 @@ hidden:
   field_date: true
   field_external_link: true
   field_flynote_local: true
+  field_iso_country_code: true
   field_judgment_mnc_old: true
   field_judgment_number: true
   field_judgment_number_override: true

--- a/config/default/core.entity_view_display.node.judgment.listing.yml
+++ b/config/default/core.entity_view_display.node.judgment.listing.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -109,6 +110,7 @@ hidden:
   field_flynote: true
   field_flynote_local: true
   field_headnote_and_holding: true
+  field_iso_country_code: true
   field_judge: true
   field_judgment_mnc_old: true
   field_judgment_number: true

--- a/config/default/core.entity_view_display.node.judgment.rss.yml
+++ b/config/default/core.entity_view_display.node.judgment.rss.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -100,6 +101,7 @@ hidden:
   field_date: true
   field_external_link: true
   field_flynote_local: true
+  field_iso_country_code: true
   field_judge: true
   field_judgment_mnc_old: true
   field_judgment_number: true

--- a/config/default/core.entity_view_display.node.judgment.search_index.yml
+++ b/config/default/core.entity_view_display.node.judgment.search_index.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -150,6 +151,7 @@ hidden:
   field_flynote: true
   field_flynote_local: true
   field_headnote_and_holding: true
+  field_iso_country_code: true
   field_judgment_mnc_old: true
   field_judgment_number: true
   field_judgment_number_override: true

--- a/config/default/core.entity_view_display.node.judgment.search_result.yml
+++ b/config/default/core.entity_view_display.node.judgment.search_result.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -100,6 +101,7 @@ hidden:
   field_flynote: true
   field_flynote_local: true
   field_headnote_and_holding: true
+  field_iso_country_code: true
   field_judge: true
   field_judgment_mnc_old: true
   field_judgment_number: true

--- a/config/default/core.entity_view_display.node.judgment.teaser.yml
+++ b/config/default/core.entity_view_display.node.judgment.teaser.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.judgment.field_flynote
     - field.field.node.judgment.field_flynote_local
     - field.field.node.judgment.field_headnote_and_holding
+    - field.field.node.judgment.field_iso_country_code
     - field.field.node.judgment.field_judge
     - field.field.node.judgment.field_judgment_mnc_old
     - field.field.node.judgment.field_judgment_number
@@ -111,6 +112,7 @@ hidden:
   field_flynote: true
   field_flynote_local: true
   field_headnote_and_holding: true
+  field_iso_country_code: true
   field_judge: true
   field_judgment_mnc_old: true
   field_judgment_number: true

--- a/config/default/core.entity_view_display.node.legislation.card.yml
+++ b/config/default/core.entity_view_display.node.legislation.card.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -82,6 +83,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_publication_name: true

--- a/config/default/core.entity_view_display.node.legislation.card_secondary.yml
+++ b/config/default/core.entity_view_display.node.legislation.card_secondary.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -82,6 +83,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_publication_name: true

--- a/config/default/core.entity_view_display.node.legislation.default.yml
+++ b/config/default/core.entity_view_display.node.legislation.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -52,6 +53,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_publication_name: true

--- a/config/default/core.entity_view_display.node.legislation.full.yml
+++ b/config/default/core.entity_view_display.node.legislation.full.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -192,6 +193,7 @@ hidden:
   field_expression_date: true
   field_external_link: true
   field_images: true
+  field_iso_country_code: true
   field_raw_json: true
   field_repeal: true
   field_stub: true

--- a/config/default/core.entity_view_display.node.legislation.listing.yml
+++ b/config/default/core.entity_view_display.node.legislation.listing.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -44,6 +45,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_publication_name: true

--- a/config/default/core.entity_view_display.node.legislation.search_index.yml
+++ b/config/default/core.entity_view_display.node.legislation.search_index.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -107,6 +108,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_publication_name: true

--- a/config/default/core.entity_view_display.node.legislation.search_result.yml
+++ b/config/default/core.entity_view_display.node.legislation.search_result.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -100,6 +101,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_raw_json: true

--- a/config/default/core.entity_view_display.node.legislation.teaser.yml
+++ b/config/default/core.entity_view_display.node.legislation.teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.legislation.field_files
     - field.field.node.legislation.field_frbr_uri
     - field.field.node.legislation.field_images
+    - field.field.node.legislation.field_iso_country_code
     - field.field.node.legislation.field_lifecycle_json
     - field.field.node.legislation.field_parent_work
     - field.field.node.legislation.field_publication_name
@@ -82,6 +83,7 @@ hidden:
   field_files: true
   field_frbr_uri: true
   field_images: true
+  field_iso_country_code: true
   field_lifecycle_json: true
   field_parent_work: true
   field_publication_name: true

--- a/config/default/field.field.node.judgment.field_iso_country_code.yml
+++ b/config/default/field.field.node.judgment.field_iso_country_code.yml
@@ -1,0 +1,29 @@
+uuid: 54168ec1-d574-490f-9e97-d748e292c652
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_iso_country_code
+    - node.type.judgment
+    - taxonomy.vocabulary.iso_country_code
+id: node.judgment.field_iso_country_code
+field_name: field_iso_country_code
+entity_type: node
+bundle: judgment
+label: 'ISO country code'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      iso_country_code: iso_country_code
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.legislation.field_iso_country_code.yml
+++ b/config/default/field.field.node.legislation.field_iso_country_code.yml
@@ -1,0 +1,29 @@
+uuid: b519f351-d291-4f71-adef-c0d5cbd10ec2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_iso_country_code
+    - node.type.legislation
+    - taxonomy.vocabulary.iso_country_code
+id: node.legislation.field_iso_country_code
+field_name: field_iso_country_code
+entity_type: node
+bundle: legislation
+label: 'ISO country code'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      iso_country_code: iso_country_code
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.storage.node.field_iso_country_code.yml
+++ b/config/default/field.storage.node.field_iso_country_code.yml
@@ -1,0 +1,20 @@
+uuid: da420d55-9ba0-4d2b-83c2-257c9eb30464
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_iso_country_code
+field_name: field_iso_country_code
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/language.content_settings.taxonomy_term.iso_country_code.yml
+++ b/config/default/language.content_settings.taxonomy_term.iso_country_code.yml
@@ -1,0 +1,11 @@
+uuid: 9030a947-081d-44f7-bf27-63a3fc482f48
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.iso_country_code
+id: taxonomy_term.iso_country_code
+target_entity_type_id: taxonomy_term
+target_bundle: iso_country_code
+default_langcode: site_default
+language_alterable: false

--- a/config/default/taxonomy.vocabulary.iso_country_code.yml
+++ b/config/default/taxonomy.vocabulary.iso_country_code.yml
@@ -1,0 +1,8 @@
+uuid: 991bd61d-afe9-429f-8b7a-70b93fd6aa19
+langcode: en
+status: true
+dependencies: {  }
+name: 'ISO Country Code'
+vid: iso_country_code
+description: ''
+weight: 0


### PR DESCRIPTION
Added ISO_country_code taxonomy field that points to ISO Country Code taxonomy to both Judgments and Legislation. Did not add to displays of either.