### PR TITLE
php-fpm setting to restart workers after 500 requests

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: vendor/bin/heroku-php-apache2 web/
+web: vendor/bin/heroku-php-apache2 -F fpm_custom.conf web/

--- a/fpm_custom.conf
+++ b/fpm_custom.conf
@@ -1,0 +1,1 @@
+pm.max_requests = 500


### PR DESCRIPTION
This should help to prevent memory bloat; ulii gets on average about 1
request per second, other sites are less.