### PR TITLE
#157 Format revision point in time banner

### DIFF
--- a/config/default/core.date_format.short_date.yml
+++ b/config/default/core.date_format.short_date.yml
@@ -1,0 +1,8 @@
+uuid: b76f478b-b224-43dc-b51c-ee60c60764ca
+langcode: en
+status: true
+dependencies: {  }
+id: short_date
+label: 'Short date'
+locked: false
+pattern: 'd M Y'

--- a/web/modules/custom/liiweb/src/LiiWebUtils.php
+++ b/web/modules/custom/liiweb/src/LiiWebUtils.php
@@ -154,7 +154,7 @@ class LiiWebUtils {
   /**
    * Extract JSON information from the given Legislation revision.
    *
-   * @param \Drupal\node\Entity\Node $node
+   * @param \Drupal\node\Entity\Node|\Drupal\Core\Entity\EntityInterface $node
    *
    * @return mixed|null
    *   Decoded JSON data.

--- a/web/modules/custom/liiweb/src/LiiWebUtils.php
+++ b/web/modules/custom/liiweb/src/LiiWebUtils.php
@@ -151,4 +151,56 @@ class LiiWebUtils {
     return NULL;
   }
 
+  /**
+   * Extract JSON information from the given Legislation revision.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *
+   * @return mixed|null
+   *   Decoded JSON data.
+   */
+  public function getLegislationJsonData($node) {
+    if ($node instanceof \Drupal\node\NodeInterface && $node->getType() == 'legislation') {
+      if (!empty($node->field_raw_json->value)) {
+        return json_decode($node->field_raw_json->value);
+      }
+    }
+    return NULL;
+  }
+
+
+  /**
+   * Load next chronological expression for a given legislation and current revision.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Legislation node
+   * @param integer $referenceRevisionId
+   *   Referenced revision
+   *
+   * @return \Drupal\node\NodeInterface
+   */
+  function getNextExpression($node, $referenceRevisionId) {
+    try {
+      $revisions = $this->entityTypeManager
+        ->getStorage('node')
+        ->revisionIds($node);
+    } catch (\Exception $e) {}
+    sort($revisions);
+    $nextRevisionId = NULL;
+    foreach($revisions as $revisionId) {
+      // Next incremental node revision ID is always the following expression chronologically
+      if ($revisionId > $referenceRevisionId) {
+        $nextRevisionId = $revisionId;
+        break;
+      }
+    }
+    if ($nextRevisionId) {
+      try {
+        return $this->entityTypeManager
+          ->getStorage('node')
+          ->loadRevision($nextRevisionId);
+      } catch (\Exception $e) {}
+    }
+    return NULL;
+  }
 }

--- a/web/modules/custom/liiweb_legislation/liiweb_legislation.module
+++ b/web/modules/custom/liiweb_legislation/liiweb_legislation.module
@@ -181,6 +181,8 @@ function liiweb_legislation_node_view(array &$build, \Drupal\Core\Entity\EntityI
   if($entity->getType() == 'legislation' && $view_mode == 'full') {
     /** @var \Drupal\liiweb\LiiWebUtils $utils */
     $utils = \Drupal::service('liiweb.utils');
+    /** @var \Drupal\liiweb_legislation\LiiWebLegislationUIHelper $legislationUtils */
+    $legislationUtils = \Drupal::service('liiweb_legislation.ui.utils');
     /** @var \Drupal\node\Entity\Node $node */
     $node = $build['#node'];
     $expressionJson = $utils->getLegislationJsonData($node);
@@ -190,48 +192,25 @@ function liiweb_legislation_node_view(array &$build, \Drupal\Core\Entity\EntityI
 
     try {
       /** @var \Drupal\node\Entity\Node $repeal */
-      $repeal = $build['#node']->field_repeal->entity->field_repeal_work->entity;
+      $repeal = $node->field_repeal->entity->field_repeal_work->entity;
     } catch (\Exception $e) {
       $repeal = NULL;
     }
-    $unknown = new TranslatableMarkup('Unknown');
     if($repeal) {
-      $repeal_date = $unknown;
-      if ($date = $build['#node']->field_repeal->entity->field_repeal_date->date) {
-        $repeal_date = \Drupal::service('date.formatter')->format(
-          $date->getTimestamp(), 'custom', 'j F, Y'
-        );
-      }
-      try {
-        $link = Link::createFromRoute($repeal->getTitle(),
-          'entity.node.canonical', ['node' => $repeal->id()]
-        )->toString();
-      } catch (\Exception $e) {
-        $link = $unknown;
-      }
+      $repealDate = $node->field_repeal->entity->field_repeal_date->date;
       $build['field_frbr_uri']['#attributes']['class'][] = 'alert-red';
       $build['field_frbr_uri'][0]['#template'] = '{{ value|raw }}';
-      $build['field_frbr_uri'][0]['#context']['value'] = new TranslatableMarkup(
-        'This legislation was repealed on <strong>@date</strong> by <h3 class="h6">@link</h3>',
-        [
-          '@date' => $repeal_date,
-          '@link' => $link
-        ]
-      );
+      $build['field_frbr_uri'][0]['#context']['value'] = $legislationUtils->formatBannerRepealedExpression($repeal, $repealDate);
     }
     elseif($node->isDefaultRevision()) {
       $build['field_frbr_uri']['#attributes']['class'][] = 'alert-primary';
-      $build['field_frbr_uri'][0]['#context']['value'] = new TranslatableMarkup('This is the latest version of this legislation.');
+      $from = $expressionJson->expression_date;
+      $build['field_frbr_uri'][0]['#context']['value'] = $legislationUtils->formatBannerCurrentExpression($from, $node->id());
     }
     else {
-      /** @var \Drupal\liiweb_legislation\LiiWebLegislationUIHelper $legislationUtils */
-      $legislationUtils = \Drupal::service('liiweb_legislation.ui.utils');
-      // $nextExpression = $utils->getNextExpression($node, $node->getLoadedRevisionId());
-      // $nextExpressionJson = $utils->getLegislationJsonData($nextExpression);
-      // $to = $nextExpressionJson->expression_date;
       $from = $expressionJson->commencement_date;
       $to = $expressionJson->in_force_to;
-      $message = $legislationUtils->formatMessageOlderExpression($from, $to, $node->id());
+      $message = $legislationUtils->formatBannerOlderExpression($from, $to, $node->id());
       $build['field_frbr_uri']['#attributes']['class'][] = 'alert-red';
       $build['field_frbr_uri'][0]['#template'] = '{{ value|raw }}';
       $build['field_frbr_uri'][0]['#context']['value'] = $message;

--- a/web/modules/custom/liiweb_legislation/liiweb_legislation.module
+++ b/web/modules/custom/liiweb_legislation/liiweb_legislation.module
@@ -179,10 +179,14 @@ function liiweb_legislation_theme() {
  */
 function liiweb_legislation_node_view(array &$build, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display, $view_mode) {
   if($entity->getType() == 'legislation' && $view_mode == 'full') {
-    $raw_json = json_decode($build['#node']->get('field_raw_json')->getValue()[0]['value']);
-    $build['#attached']['drupalSettings']['liiweb_legislation']['raw_json'] = $raw_json;
+    /** @var \Drupal\liiweb\LiiWebUtils $utils */
+    $utils = \Drupal::service('liiweb.utils');
+    /** @var \Drupal\node\Entity\Node $node */
+    $node = $build['#node'];
+    $expressionJson = $utils->getLegislationJsonData($node);
+    $build['#attached']['drupalSettings']['liiweb_legislation']['raw_json'] = $expressionJson;
     // stash the country code for use when displaying the legislation content
-    $build['field_content']['country'] = $raw_json->country;
+    $build['field_content']['country'] = $expressionJson->country;
 
     try {
       /** @var \Drupal\node\Entity\Node $repeal */
@@ -215,31 +219,22 @@ function liiweb_legislation_node_view(array &$build, \Drupal\Core\Entity\EntityI
         ]
       );
     }
-    elseif($build['#node']->isDefaultRevision()) {
+    elseif($node->isDefaultRevision()) {
       $build['field_frbr_uri']['#attributes']['class'][] = 'alert-primary';
       $build['field_frbr_uri'][0]['#context']['value'] = new TranslatableMarkup('This is the latest version of this legislation.');
     }
     else {
-      $vid = \Drupal::entityTypeManager()->getStorage('node')->getLatestRevisionId($build['#node']->id());
-      $node = \Drupal::entityTypeManager()->getStorage('node')->loadRevision($vid);
-      //WORK IN FORCE FIELDS TO BE UPDATED
-      // TODO format date nicely as above j F, Y
-      $from = $raw_json->commencement_date;
-      $to = $raw_json->commencement_date;
-      try {
-        $link = Link::createFromRoute(
-          new TranslatableMarkup('Read the version currently in force.'),
-          'entity.node.canonical', ['node' => $node->id()]
-        )->toString();
-      } catch (\Exception $e) {
-        $link = $unknown;
-      }
+      /** @var \Drupal\liiweb_legislation\LiiWebLegislationUIHelper $legislationUtils */
+      $legislationUtils = \Drupal::service('liiweb_legislation.ui.utils');
+      // $nextExpression = $utils->getNextExpression($node, $node->getLoadedRevisionId());
+      // $nextExpressionJson = $utils->getLegislationJsonData($nextExpression);
+      // $to = $nextExpressionJson->expression_date;
+      $from = $expressionJson->commencement_date;
+      $to = $expressionJson->in_force_to;
+      $message = $legislationUtils->formatMessageOlderExpression($from, $to, $node->id());
       $build['field_frbr_uri']['#attributes']['class'][] = 'alert-red';
       $build['field_frbr_uri'][0]['#template'] = '{{ value|raw }}';
-      $build['field_frbr_uri'][0]['#context']['value'] = new TranslatableMarkup(
-        'This is the version of this legislation as it was from @from to @to. <h3 class="h6">@link</h3>',
-        ['@from' => $from, '@to' => $to, '@link' => $link]
-      );
+      $build['field_frbr_uri'][0]['#context']['value'] = $message;
     }
   }
 }

--- a/web/modules/custom/liiweb_legislation/liiweb_legislation.services.yml
+++ b/web/modules/custom/liiweb_legislation/liiweb_legislation.services.yml
@@ -1,0 +1,4 @@
+services:
+  liiweb_legislation.ui.utils:
+    class: Drupal\liiweb_legislation\LiiWebLegislationUIHelper
+    arguments: ['@date.formatter', '@entity_type.manager', '@liiweb.utils']

--- a/web/modules/custom/liiweb_legislation/liiweb_legislation.services.yml
+++ b/web/modules/custom/liiweb_legislation/liiweb_legislation.services.yml
@@ -1,4 +1,4 @@
 services:
   liiweb_legislation.ui.utils:
     class: Drupal\liiweb_legislation\LiiWebLegislationUIHelper
-    arguments: ['@date.formatter', '@entity_type.manager', '@liiweb.utils']
+    arguments: ['@date.formatter', '@entity_type.manager']

--- a/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
+++ b/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
@@ -39,14 +39,53 @@ class LiiWebLegislationUIHelper {
     $this->liiWebUtils = $liiWebUtils;
   }
 
-  public function formatMessageOlderExpression($fromStr, $toStr, $nid) {
+  /**
+   * Format the banner for the newest version of the legislation.
+   *
+   * @param string $fromStr
+   *   Start date in format YYYY-MM-DD.
+   * @param integer $nid
+   *   Expression node ID.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup|string
+   *   Formatted banner message.
+   */
+  public function formatBannerCurrentExpression($fromStr, $nid) {
+    $default = new TranslatableMarkup('This is the latest version of this legislation');
+    if (empty($fromStr)) {
+      return $default;
+    }
+    $from = \DateTime::createFromFormat('Y-m-d', $fromStr, new \DateTimeZone('UTC'));
+    if (empty($from)) {
+      return $default;
+    }
+    $from->setTime(0, 0);
+    $fromFormatted = $this->dateFormatter->format($from->getTimestamp(), 'short_date');
+    return new TranslatableMarkup('This is the latest version of this legislation commenced on <strong>@from</strong>.', ['@from' => $fromFormatted]);
+  }
+
+  /**
+   * Generate banner message on older expressions of the legislation.
+   *
+   * @param string $fromStr
+   *   Start date in format YYYY-MM-DD.
+   * @param string $toStr
+   *   End date in format YYYY-MM-DD.
+   * @param integer $nid
+   *   Expression node ID.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup|string
+   *   Formatted banner message.
+   */
+  public function formatBannerOlderExpression($fromStr, $toStr, $nid) {
+    $default = new TranslatableMarkup('This is not the latest version of this legislation.');
     if (empty($fromStr) || empty($toStr)) {
-      return '';
+      return $default;
     }
     $from = \DateTime::createFromFormat('Y-m-d', $fromStr, new \DateTimeZone('UTC'));
     $to = \DateTime::createFromFormat('Y-m-d', $toStr, new \DateTimeZone('UTC'));
     if (empty($from) || empty($to)) {
-      return '';
+      return $default;
     }
     $from->setTime(0, 0);
     $to->setTime(0, 0);
@@ -66,7 +105,7 @@ class LiiWebLegislationUIHelper {
       }
       if ($latestRevisionFromFormatted) {
         $link = Link::createFromRoute(
-          new TranslatableMarkup('Read the version currently in force from <strong>@from</strong>.', ['@from' => $latestRevisionFromFormatted]),
+          new TranslatableMarkup('Read the current version commenced on <strong>@from</strong>.', ['@from' => $latestRevisionFromFormatted]),
           'entity.node.canonical', ['node' => $nid]
         )->toString();
       }
@@ -82,6 +121,38 @@ class LiiWebLegislationUIHelper {
     return new TranslatableMarkup(
       'This is the version of this legislation as it was from <strong>@from</strong> to <strong>@to</strong>. <h3 class="h6">@link</h3>',
       ['@from' => $fromFormatted, '@to' => $toFormatted, '@link' => $link]
+    );
+  }
+
+  /**
+   * @param \Drupal\node\NodeInterface $repealWork
+   *   Work that repealed the current legislation.
+   * @param \DateTime $repealDate
+   *   Date of repeal.
+   *
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
+   */
+  public function formatBannerRepealedExpression($repealWork, $repealDate) {
+    $default = new TranslatableMarkup('This legislation was repealed.');
+    if (empty($repealDate)) {
+      return $default;
+    }
+    $repealDateFormatted = $this->dateFormatter->format($repealDate->getTimestamp(), 'short_date');
+    try {
+      $link = Link::createFromRoute($repealWork->getTitle(),
+        'entity.node.canonical',
+        ['node' => $repealWork->id()],
+        ['attributes' => ['title' => new TranslatableMarkup('Click to read this legislation')]]
+      )->toString();
+    } catch (\Exception $e) {
+      $link = new TranslatableMarkup('Unknown');
+    }
+    return new TranslatableMarkup(
+      'This legislation was repealed on <strong>@date</strong> by <h3 class="h6">@link</h3>.',
+      [
+        '@date' => $repealDateFormatted,
+        '@link' => $link
+      ]
     );
   }
 

--- a/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
+++ b/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
@@ -25,18 +25,12 @@ class LiiWebLegislationUIHelper {
   protected $dateFormatter;
 
   /**
-   * @var \Drupal\liiweb\LiiWebUtils
-   */
-  protected $liiWebUtils;
-
-  /**
    * Constructs a new LegislationUIHelper object.
    * {@inheritDoc}
    */
-  public function __construct(DateFormatter $dateFormatter, EntityTypeManagerInterface $entity_type_manager, LiiWebUtils $liiWebUtils) {
+  public function __construct(DateFormatter $dateFormatter, EntityTypeManagerInterface $entity_type_manager) {
     $this->dateFormatter = $dateFormatter;
     $this->entityTypeManager = $entity_type_manager;
-    $this->liiWebUtils = $liiWebUtils;
   }
 
   /**
@@ -78,6 +72,8 @@ class LiiWebLegislationUIHelper {
    *   Formatted banner message.
    */
   public function formatBannerOlderExpression($fromStr, $toStr, $nid) {
+    /** @var LiiWebUtils $liiWebUtils */
+    $liiWebUtils = \Drupal::service('liiweb.utils');
     $default = new TranslatableMarkup('This is not the latest version of this legislation.');
     if (empty($fromStr) || empty($toStr)) {
       return $default;
@@ -94,7 +90,7 @@ class LiiWebLegislationUIHelper {
     try {
       $latestVid = $this->entityTypeManager->getStorage('node')->getLatestRevisionId($nid);
       $node = $this->entityTypeManager->getStorage('node')->loadRevision($latestVid);
-      $json = $this->liiWebUtils->getLegislationJsonData($node);
+      $json = $liiWebUtils->getLegislationJsonData($node);
       // Get the date of the newest revision.
       $latestRevisionFromFormatted = NULL;
       if ($latestRevisionFromStr = $json->expression_date) {

--- a/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
+++ b/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
@@ -45,7 +45,7 @@ class LiiWebLegislationUIHelper {
    *   Formatted banner message.
    */
   public function formatBannerCurrentExpression($fromStr, $nid) {
-    $default = new TranslatableMarkup('This is the latest version of this legislation');
+    $default = new TranslatableMarkup('This is the latest version of this legislation.');
     if (empty($fromStr)) {
       return $default;
     }

--- a/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
+++ b/web/modules/custom/liiweb_legislation/src/LiiWebLegislationUIHelper.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\liiweb_legislation;
+
+use Drupal\Core\Datetime\DateFormatter;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\liiweb\LiiWebUtils;
+
+class LiiWebLegislationUIHelper {
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Drupal\Core\Datetime\DateFormatterInterface definition.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * @var \Drupal\liiweb\LiiWebUtils
+   */
+  protected $liiWebUtils;
+
+  /**
+   * Constructs a new LegislationUIHelper object.
+   * {@inheritDoc}
+   */
+  public function __construct(DateFormatter $dateFormatter, EntityTypeManagerInterface $entity_type_manager, LiiWebUtils $liiWebUtils) {
+    $this->dateFormatter = $dateFormatter;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->liiWebUtils = $liiWebUtils;
+  }
+
+  public function formatMessageOlderExpression($fromStr, $toStr, $nid) {
+    if (empty($fromStr) || empty($toStr)) {
+      return '';
+    }
+    $from = \DateTime::createFromFormat('Y-m-d', $fromStr, new \DateTimeZone('UTC'));
+    $to = \DateTime::createFromFormat('Y-m-d', $toStr, new \DateTimeZone('UTC'));
+    if (empty($from) || empty($to)) {
+      return '';
+    }
+    $from->setTime(0, 0);
+    $to->setTime(0, 0);
+    $fromFormatted = $this->dateFormatter->format($from->getTimestamp(), 'short_date');
+    $toFormatted = $this->dateFormatter->format($to->getTimestamp(), 'short_date');
+    try {
+      $latestVid = $this->entityTypeManager->getStorage('node')->getLatestRevisionId($nid);
+      $node = $this->entityTypeManager->getStorage('node')->loadRevision($latestVid);
+      $json = $this->liiWebUtils->getLegislationJsonData($node);
+      // Get the date of the newest revision.
+      $latestRevisionFromFormatted = NULL;
+      if ($latestRevisionFromStr = $json->expression_date) {
+        if ($latestRevisionFrom = \DateTime::createFromFormat('Y-m-d', $latestRevisionFromStr, new \DateTimeZone('UTC'))) {
+          $latestRevisionFrom->setTime(0, 0);
+          $latestRevisionFromFormatted = $this->dateFormatter->format($latestRevisionFrom->getTimestamp(), 'short_date');
+        }
+      }
+      if ($latestRevisionFromFormatted) {
+        $link = Link::createFromRoute(
+          new TranslatableMarkup('Read the version currently in force from <strong>@from</strong>.', ['@from' => $latestRevisionFromFormatted]),
+          'entity.node.canonical', ['node' => $nid]
+        )->toString();
+      }
+      else {
+        $link = Link::createFromRoute(
+          new TranslatableMarkup('Read the version currently in force.'),
+          'entity.node.canonical', ['node' => $nid]
+        )->toString();
+      }
+    } catch (\Exception $e) {
+      $link = new TranslatableMarkup('Unknown');;
+    }
+    return new TranslatableMarkup(
+      'This is the version of this legislation as it was from <strong>@from</strong> to <strong>@to</strong>. <h3 class="h6">@link</h3>',
+      ['@from' => $fromFormatted, '@to' => $toFormatted, '@link' => $link]
+    );
+  }
+
+}


### PR DESCRIPTION
I have implemented the banner formatting fixes and they look like the following:

1. Current version of the banner `/akn/za/act/gn/2020/416/eng@2021-06-30`

![image](https://user-images.githubusercontent.com/634661/134862473-109707b5-25a8-45f0-b1ff-f7e70370516b.png)


2. Older version of the banner `/akn/za/act/gn/2020/416/eng@2021-03-26`

![image](https://user-images.githubusercontent.com/634661/134862883-db5b2c94-e56c-4829-80d3-c182c9dd2135.png)


3. Repealed version of the banner `/akn/za/act/gn/2021/r167/eng@2021-03-03`

![image](https://user-images.githubusercontent.com/634661/134863055-9bdf1bfc-a0ac-40e7-84ba-cfe5e045997d.png)
