### PR TITLE
Redirect /index.php/foo to /foo

### DIFF
--- a/nginx/liiweb.conf
+++ b/nginx/liiweb.conf
@@ -1,2 +1,13 @@
 # put this into dokku/countrylii/nginx.conf.d/
 client_max_body_size 30M;
+
+# Enforce clean URLs
+# Removes index.php from urls like www.example.com/index.php/my-page --> www.example.com/my-page
+# Could be done with 301 for permanent or other redirect codes.
+# See https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/
+if ($request_uri ~* "^(.*/)index\.php/(.*)") {
+  return 301 $1$2;
+}
+if ($request_uri ~* "^(.*/)index\.php") {
+  return 301 $1;
+}


### PR DESCRIPTION
I've updated this on the production hosts.