### PR TITLE
Addition of Advocate, Attorney and Order fields

### DIFF
--- a/config/default/core.entity_form_display.node.judgment.default.yml
+++ b/config/default/core.entity_form_display.node.judgment.default.yml
@@ -5,7 +5,11 @@ dependencies:
   config:
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -28,6 +32,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -62,6 +67,7 @@ third_party_settings:
         - field_flynote_local
         - field_search_summary
         - field_headnote_and_holding
+        - field_order
       parent_name: group_group
       weight: 22
       format_type: tab
@@ -91,6 +97,10 @@ third_party_settings:
         - field_judge
         - field_law_report_citations
         - field_case_number
+        - field_advocate_s_for_the_applica
+        - field_advocate_s_for_the_respond
+        - field_attorney_s_for_the_applica
+        - field_attorney_s_for_the_respond
       parent_name: group_group
       weight: 21
       format_type: tab
@@ -172,6 +182,26 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_advocate_s_for_the_applica:
+    weight: 29
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_advocate_s_for_the_respond:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   field_arbitrary_suffix:
     weight: 27
     settings:
@@ -179,6 +209,26 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_attorney_s_for_the_applica:
+    weight: 31
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_attorney_s_for_the_respond:
+    weight: 32
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_case_name:
     weight: 12
@@ -350,6 +400,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: computed_string_widget
+    region: content
+  field_order:
+    weight: 28
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
     region: content
   field_search_summary:
     weight: 20

--- a/config/default/core.entity_view_display.node.judgment.card_secondary.yml
+++ b/config/default/core.entity_view_display.node.judgment.card_secondary.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.card_secondary
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -98,7 +103,11 @@ content:
 hidden:
   body: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number: true
   field_case_number_numeric: true
@@ -120,6 +129,7 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   field_search_summary: true
   langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.judgment.default.yml
+++ b/config/default/core.entity_view_display.node.judgment.default.yml
@@ -5,7 +5,11 @@ dependencies:
   config:
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -28,6 +32,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -193,7 +198,11 @@ content:
 hidden:
   body: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number_numeric: true
   field_case_number_old: true
@@ -208,6 +217,7 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.judgment.full.yml
+++ b/config/default/core.entity_view_display.node.judgment.full.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -252,7 +257,11 @@ content:
 hidden:
   body: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_number_numeric: true
   field_case_number_old: true
   field_case_number_year: true
@@ -266,6 +275,7 @@ hidden:
   field_judgment_old_nid: true
   field_locality: true
   field_matter_type: true
+  field_order: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.judgment.listing.yml
+++ b/config/default/core.entity_view_display.node.judgment.listing.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.listing
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -98,7 +103,11 @@ content:
 hidden:
   body: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number: true
   field_case_number_numeric: true
@@ -121,6 +130,7 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.judgment.rss.yml
+++ b/config/default/core.entity_view_display.node.judgment.rss.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.rss
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -92,7 +97,11 @@ content:
     third_party_settings: {  }
 hidden:
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number: true
   field_case_number_numeric: true
@@ -111,6 +120,7 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.judgment.search_index.yml
+++ b/config/default/core.entity_view_display.node.judgment.search_index.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.search_index
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -141,7 +146,11 @@ hidden:
   body: true
   download_conditional_entity_view_1: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number: true
   field_case_number_numeric: true
@@ -160,5 +169,6 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.judgment.search_result.yml
+++ b/config/default/core.entity_view_display.node.judgment.search_result.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.search_result
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -89,7 +94,11 @@ content:
 hidden:
   body: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number: true
   field_case_number_numeric: true
@@ -112,6 +121,7 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   field_search_summary: true
   langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.judgment.teaser.yml
+++ b/config/default/core.entity_view_display.node.judgment.teaser.yml
@@ -6,7 +6,11 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.judgment.body
     - field.field.node.judgment.feeds_item
+    - field.field.node.judgment.field_advocate_s_for_the_applica
+    - field.field.node.judgment.field_advocate_s_for_the_respond
     - field.field.node.judgment.field_arbitrary_suffix
+    - field.field.node.judgment.field_attorney_s_for_the_applica
+    - field.field.node.judgment.field_attorney_s_for_the_respond
     - field.field.node.judgment.field_case_name
     - field.field.node.judgment.field_case_number
     - field.field.node.judgment.field_case_number_numeric
@@ -29,6 +33,7 @@ dependencies:
     - field.field.node.judgment.field_locality
     - field.field.node.judgment.field_matter_type
     - field.field.node.judgment.field_media_neutral_citation
+    - field.field.node.judgment.field_order
     - field.field.node.judgment.field_search_summary
     - node.type.judgment
   module:
@@ -100,7 +105,11 @@ content:
 hidden:
   body: true
   feeds_item: true
+  field_advocate_s_for_the_applica: true
+  field_advocate_s_for_the_respond: true
   field_arbitrary_suffix: true
+  field_attorney_s_for_the_applica: true
+  field_attorney_s_for_the_respond: true
   field_case_name: true
   field_case_number: true
   field_case_number_numeric: true
@@ -123,5 +132,6 @@ hidden:
   field_locality: true
   field_matter_type: true
   field_media_neutral_citation: true
+  field_order: true
   langcode: true
   links: true

--- a/config/default/field.field.node.judgment.field_advocate_s_for_the_applica.yml
+++ b/config/default/field.field.node.judgment.field_advocate_s_for_the_applica.yml
@@ -1,0 +1,29 @@
+uuid: 727ef013-c9c1-428a-b8a3-507e893b4e98
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_advocate_s_for_the_applica
+    - node.type.judgment
+    - taxonomy.vocabulary.advocate_s_
+id: node.judgment.field_advocate_s_for_the_applica
+field_name: field_advocate_s_for_the_applica
+entity_type: node
+bundle: judgment
+label: 'Advocate(s) for the applicant'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      advocate_s_: advocate_s_
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.judgment.field_advocate_s_for_the_respond.yml
+++ b/config/default/field.field.node.judgment.field_advocate_s_for_the_respond.yml
@@ -1,0 +1,29 @@
+uuid: 090874f2-9180-41f0-8401-d4c2687ba450
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_advocate_s_for_the_respond
+    - node.type.judgment
+    - taxonomy.vocabulary.advocate_s_
+id: node.judgment.field_advocate_s_for_the_respond
+field_name: field_advocate_s_for_the_respond
+entity_type: node
+bundle: judgment
+label: 'Advocate(s) for the respondent'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      advocate_s_: advocate_s_
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.judgment.field_attorney_s_for_the_applica.yml
+++ b/config/default/field.field.node.judgment.field_attorney_s_for_the_applica.yml
@@ -1,0 +1,29 @@
+uuid: 03bec6aa-cc13-455f-b1bd-a5dffa20909a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_attorney_s_for_the_applica
+    - node.type.judgment
+    - taxonomy.vocabulary.attorney_s_
+id: node.judgment.field_attorney_s_for_the_applica
+field_name: field_attorney_s_for_the_applica
+entity_type: node
+bundle: judgment
+label: 'Attorney(s) for the applicant'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      attorney_s_: attorney_s_
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.judgment.field_attorney_s_for_the_respond.yml
+++ b/config/default/field.field.node.judgment.field_attorney_s_for_the_respond.yml
@@ -1,0 +1,29 @@
+uuid: 8923c056-b1da-459f-b3bd-cccd14df7067
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_attorney_s_for_the_respond
+    - node.type.judgment
+    - taxonomy.vocabulary.attorney_s_
+id: node.judgment.field_attorney_s_for_the_respond
+field_name: field_attorney_s_for_the_respond
+entity_type: node
+bundle: judgment
+label: 'Attorney(s) for the respondent'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      attorney_s_: attorney_s_
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.judgment.field_order.yml
+++ b/config/default/field.field.node.judgment.field_order.yml
@@ -1,0 +1,21 @@
+uuid: 951f8f7e-663c-46dd-9a42-175a91ca5c46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_order
+    - node.type.judgment
+  module:
+    - text
+id: node.judgment.field_order
+field_name: field_order
+entity_type: node
+bundle: judgment
+label: Order
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/field.storage.node.field_advocate_s_for_the_applica.yml
+++ b/config/default/field.storage.node.field_advocate_s_for_the_applica.yml
@@ -1,0 +1,20 @@
+uuid: 500e560b-ea86-4690-9d76-72494838ce37
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_advocate_s_for_the_applica
+field_name: field_advocate_s_for_the_applica
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_advocate_s_for_the_respond.yml
+++ b/config/default/field.storage.node.field_advocate_s_for_the_respond.yml
@@ -1,0 +1,20 @@
+uuid: 8fd612cb-337e-4a42-ad27-2d172b43eb3d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_advocate_s_for_the_respond
+field_name: field_advocate_s_for_the_respond
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_attorney_s_for_the_applica.yml
+++ b/config/default/field.storage.node.field_attorney_s_for_the_applica.yml
@@ -1,0 +1,20 @@
+uuid: 03f8465f-92c8-41ae-9a44-2f33d45addb4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_attorney_s_for_the_applica
+field_name: field_attorney_s_for_the_applica
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_attorney_s_for_the_respond.yml
+++ b/config/default/field.storage.node.field_attorney_s_for_the_respond.yml
@@ -1,0 +1,20 @@
+uuid: 2b99cc8c-279e-4773-b7fe-8f35fe42ad8c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_attorney_s_for_the_respond
+field_name: field_attorney_s_for_the_respond
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/field.storage.node.field_order.yml
+++ b/config/default/field.storage.node.field_order.yml
@@ -1,0 +1,19 @@
+uuid: 20130801-daac-4c65-909c-58db6536c622
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_order
+field_name: field_order
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/language.content_settings.taxonomy_term.advocate_s_.yml
+++ b/config/default/language.content_settings.taxonomy_term.advocate_s_.yml
@@ -1,0 +1,11 @@
+uuid: 4f1baf7e-adf2-487e-9717-9acbffbb7082
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.advocate_s_
+id: taxonomy_term.advocate_s_
+target_entity_type_id: taxonomy_term
+target_bundle: advocate_s_
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.attorney_s_.yml
+++ b/config/default/language.content_settings.taxonomy_term.attorney_s_.yml
@@ -1,0 +1,11 @@
+uuid: 59717109-cc5c-442c-a533-f5eb790be39c
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.attorney_s_
+id: taxonomy_term.attorney_s_
+target_entity_type_id: taxonomy_term
+target_bundle: attorney_s_
+default_langcode: site_default
+language_alterable: false

--- a/config/default/taxonomy.vocabulary.advocate_s_.yml
+++ b/config/default/taxonomy.vocabulary.advocate_s_.yml
@@ -1,0 +1,8 @@
+uuid: 38360f08-f1d6-493a-8d7a-77424f2051ca
+langcode: en
+status: true
+dependencies: {  }
+name: Advocate(s)
+vid: advocate_s_
+description: ''
+weight: 0

--- a/config/default/taxonomy.vocabulary.attorney_s_.yml
+++ b/config/default/taxonomy.vocabulary.attorney_s_.yml
@@ -1,0 +1,8 @@
+uuid: cf79d153-806c-4256-aad9-3b9f8f019862
+langcode: en
+status: true
+dependencies: {  }
+name: Attorney(s)
+vid: attorney_s_
+description: ''
+weight: 0


### PR DESCRIPTION
Added the following fields: to resolve #306 and #307 

Order - Long text, Formatted
Advocate(s) for the applicant 
Advocate(s) for the respondent
Attorney(s) for the applicant
Attorney(s) for the respondent
Taxonomy multi-value fields.