### PR TITLE
Remove set permanent files patch

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -9,9 +9,6 @@
     },
     "drupal/facets": {
       "Test scanning fails with The 'core' or the 'core_version_requirement' key must be present ...": "patches/facets/3182762-1.diff"
-    },
-    "drupal/filefield_paths": {
-      "Set permanent status on files": "patches/filefield_paths/filefield_paths-set_permanent-3175118-0.patch"
     }
   }
 }

--- a/config/default/search_api_attachments.admin_config.yml
+++ b/config/default/search_api_attachments.admin_config.yml
@@ -1,4 +1,4 @@
-extraction_method: solr_extractor
+extraction_method: tika_extractor
 preserve_cache: true
 solr_extractor_configuration:
   solr_server: solr


### PR DESCRIPTION
Set search api attachments back to Tika, remove patch to set file fields to permanent until S3 issue is resolved.